### PR TITLE
docs: add folder creation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Custom Builds of the Webfont.
 
 ## Usage
 
-Clone repo, and run `npm install`.
+Clone repo, run `npm install`, and create (empty) `icons` folder.
 
 ## Commands
 


### PR DESCRIPTION
If the `icons` directory does not exist when the script is run the user will see an error message. Example:
```text
$ npm run buildIcons

> @mdi/font-build@0.1.0 buildIcons /home/user/tmp/MaterialDesign-Webfont-Build
> node buildIcons.js

fs.js:115
    throw err;
    ^

Error: ENOENT: no such file or directory, open 'icons/access-point.svg'
    at Object.openSync (fs.js:436:3)
    at Object.writeFileSync (fs.js:1187:35)
    at Object.exports.write (/home/user/tmp/MaterialDesign-Webfont-Build/node_modules/@mdi/util/util.js:29:6)
    at meta.forEach.icon (/home/user/tmp/MaterialDesign-Webfont-Build/buildIcons.js:7:10)
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/home/user/tmp/MaterialDesign-Webfont-Build/buildIcons.js:6:20)
    at Module._compile (internal/modules/cjs/loader.js:688:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)
    at Module.load (internal/modules/cjs/loader.js:598:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:537:12)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @mdi/font-build@0.1.0 buildIcons: `node buildIcons.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @mdi/font-build@0.1.0 buildIcons script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/user/.npm/_logs/2018-11-19T16_36_31_153Z-debug.log
```

Alternatively, [@mdi/util](https://github.com/Templarian/MaterialDesign-Util/blob/master/util.js#L28) could be updated to call [`ensureDir`](https://github.com/jprichardson/node-fs-extra/blob/master/docs/ensureDir.md) (from [`fs-extra`]())https://github.com/jprichardson/node-fs-extra or [`mkdirSync`](https://nodejs.org/dist/latest-v10.x/docs/api/fs.html#fs_fs_mkdirsync_path_options) before calling [`writeFileSync`](https://nodejs.org/dist/latest-v10.x/docs/api/fs.html#fs_fs_writefilesync_file_data_options).